### PR TITLE
If number for SMS to be sent is in E.164 format (starts with a '+'), …

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ __commandTimeout__: milliseconds, how long to wait for response on any AT comman
 
 __ussdTimeout__: milliseconds, how long to wait for USSD after sending the command. _Default: 15000_
 
+__forever__: boolean, indicated whether module should run in daemon mode automatically handling modem connects and disconnects. _Default: false_
+
 API
 ===
 See wiki [page](https://github.com/paintenzero/node-gsm-modem/wiki/api).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Checked on modems
 * Huawei 3121S
 * Huawei E171 / E173
 * Huawei E1550
+* Huawei K3765
 * ZTE MF656A
 * ZTE MF180
 * Wavecom WISMO2C

--- a/index.js
+++ b/index.js
@@ -460,6 +460,14 @@ Modem.prototype.handleNotification = function (line) {
   else if(line.substr(0, 5) === '^CEND') {
     handled = true;
   }
+  else if(line.substr(0,10) === '^DSFLOWRPT') {
+    //These events are emitted by modem when it is connected to internet through ppp
+    //See: http://www.sakis3g.com/
+    handled = true;
+  }
+  else if(line.substr(0,5) === '^BOOT') {
+    handled = true;
+  }
   return handled;
 };
 /**

--- a/index.js
+++ b/index.js
@@ -869,7 +869,7 @@ Modem.prototype.sendSMS = function (message, cb) {
 
   if (!this.textMode) {
     var opts = message;
-    if(message.receiver.indexOf("+") === 0) {
+    if(message.receiver && message.receiver.indexOf("+") === 0) {
       message.receiver = message.receiver.substring(1);
       opts.receiver_type = 0x91;
     }
@@ -877,7 +877,7 @@ Modem.prototype.sendSMS = function (message, cb) {
       opts.receiver_type = 0x81;
     }
 
-    if(message.smsc.indexOf("+") === 0) {
+    if(message.smsc && message.smsc.indexOf("+") === 0) {
       message.smsc = message.smsc.substring(1);
       opts.smsc_type = 0x91;
     }

--- a/index.js
+++ b/index.js
@@ -800,9 +800,14 @@ Modem.prototype.sendSMS = function (message, cb) {
 
   if (!this.textMode) {
     var opts = message;
-    if (opts.receiver_type === undefined) {
+    if(message.receiver.indexOf("+") === 0) {
+      message.receiver = message.receiver.substring(1);
       opts.receiver_type = 0x91;
     }
+    else {
+      opts.receiver_type = 0x81;
+    }
+
     if (opts.encoding === undefined) {
       opts.encoding = isGSMAlphabet(opts.text) ? '7bit' : '16bit';
     }

--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ function Modem(opts) {
 
   this.forever = opts.forever;
 
+  this.connectingHandle;
+
   this.logger = intel.getLogger();
   if (opts.debug) {
       this.logger.setLevel(intel.DEBUG);
@@ -235,7 +237,7 @@ Modem.prototype.onPortConnected = function (port, dataMode, cb) {
       }
       if(this.forever) {
         //Retry connecting in 1 sec
-        setTimeout(function() {
+        this.connectingHandle = setTimeout(function() {
           this.logger.debug("Retrying to connect...");
           this.resetVars();
           this.connect(cb);
@@ -272,6 +274,7 @@ Modem.prototype.close = function (cb) {
   var i = 0;
   this.logger.debug('Modem disconnect called');
   this.connected = false;
+
   try {
     for (i; i < this.serialPorts.length; ++i) {
       this.serialPorts[i].close(this.onClose.bind(this, cb));
@@ -280,6 +283,16 @@ Modem.prototype.close = function (cb) {
     this.logger.error('Error closing modem: %s', err.message);
   }
 };
+/**
+ * Stops the reconnection loop and disconnects the modem if it is connected
+ */
+Modem.prototype.stopForever = function() {
+  this.forever = false;
+  if(this.connectingHandle) {
+    clearTimeout(this.connectingHandle);
+  }
+  this.close();
+}
 /**
  * Is called when the port is closed
  */

--- a/index.js
+++ b/index.js
@@ -538,7 +538,7 @@ Modem.prototype.getSMSCenter = function (cb) {
   "use strict";
   this.sendCommand('AT+CSCA?', function (data) {
     if (typeof cb === 'function') {
-      var match = data.match(/\+CSCA:\s*"?([0-9]*)"?,(\d*)/);
+      var match = data.match(/\+CSCA:\s*"(.?[0-9]*)".?,(\d*)/);
       if (match) {
         cb(undefined, match[1]);
       } else {
@@ -806,6 +806,14 @@ Modem.prototype.sendSMS = function (message, cb) {
     }
     else {
       opts.receiver_type = 0x81;
+    }
+
+    if(message.smsc.indexOf("+") === 0) {
+      message.smsc = message.smsc.substring(1);
+      opts.smsc_type = 0x91;
+    }
+    else {
+      opts.smsc_type = 0x81;
     }
 
     if (opts.encoding === undefined) {


### PR DESCRIPTION
…set receiver type as 0x91, otherwise set receiver type as 0x81

This commit allows you to specify recipient number in E.164 format starting with a '+' (and if so, we can be sure it is it is an international number, thus 0x91should be used as type). 

It further assumes that if a number does not start with a '+', we cannot be sure it is an international number, thus 0x81 should be used as type.
