### PR TITLE
dependencies updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.3.19",
   "author": "Sergey Birukov <sergeyb26@gmail.com>",
   "dependencies": {
-    "serialport": "~> 1.4",
-    "intel": "~1.0.0"
+    "intel": "^1.0.2",
+    "serialport": "^2.0.5"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
I was having trouble to install this module because serialport ~1.4 is incompatible with node >4 (can't be builded). I'd also took the chanse to update the intel module.

I'm currently using this and it seems there is no problems with the update. 
